### PR TITLE
GitHub MCPサーバーに関する記事を追加

### DIFF
--- a/articles/github-mcp-claude-zenn.md
+++ b/articles/github-mcp-claude-zenn.md
@@ -3,7 +3,7 @@ title: "GitHub MCPサーバーを使ってClaude DesktopからZenn記事を公�
 emoji: "🚀"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["Claude", "GitHub", "MCP", "Zenn", "AIアシスタント"]
-published: false
+published: true
 ---
 
 ## はじめに


### PR DESCRIPTION
GitHub MCPサーバーを使ってClaude DesktopからZenn記事を公開する方法についての新しい記事を追加しました。

## 追加内容
- GitHub MCPサーバーの設定方法
- Claude DesktopとGitHubの連携方法
- Zenn記事の公開・管理ワークフロー
- トラブルシューティング

この記事は `published: true` で設定されており、マージ後に公開されます。