### PR TITLE
Update: Discord を例の1つとして扱い、Zenn の説明を追加

### DIFF
--- a/articles/openclaw-discord-zenn-x-automation.md
+++ b/articles/openclaw-discord-zenn-x-automation.md
@@ -1,8 +1,8 @@
 ---
-title: "Discord でポチるだけ！OpenClaw で Zenn 記事公開 → X 拡散を完全自動化する"
+title: "OpenClaw で Zenn 記事公開 → X 拡散を完全自動化する"
 emoji: "🤖"
 type: "tech"
-topics: ["OpenClaw", "Discord", "Zenn", "X", "自動化"]
+topics: ["OpenClaw", "Zenn", "X", "自動化", "GitHub"]
 published: false
 publication_name: "iwakenlab_book"
 ---
@@ -11,20 +11,45 @@ publication_name: "iwakenlab_book"
 
 技術記事を書くのは楽しいけれど、公開作業や SNS 拡散が面倒……そんな経験ありませんか？
 
-- Zenn の記事を GitHub に push して PR 作って……
+- 記事を GitHub に push して PR 作って……
 - 記事を公開したら X (Twitter) でツイート文を考えて投稿して……
 - こういう繰り返し作業、自動化できたらいいのに……
 
-**OpenClaw の Skill 機能を使えば、Discord で一言つぶやくだけで、記事執筆から X 拡散までを完全自動化できます。**
+**OpenClaw の Skill 機能を使えば、記事執筆から X 拡散までを完全自動化できます。**
 
-この記事では、実際に構築した **「Discord → Zenn 記事公開 → X 投稿」の完全自動化フロー**を解説します。
+この記事では、実際に構築した **「Zenn 記事公開 → X 投稿」の完全自動化フロー**を解説します。
+
+# Zenn とは？なぜ自動化に向いているのか
+
+Zenn は **GitHub で記事を管理できる技術ブログプラットフォーム**です。
+
+**Zenn が自動化に最適な理由：**
+
+1. **Git ベースで記事管理**
+   - Markdown ファイルで記事を書く
+   - バージョン管理が簡単
+   - ローカルでも編集可能
+
+2. **GitHub と連携**
+   - GitHub リポジトリと自動同期
+   - PR ベースのワークフローが使える
+   - master ブランチにマージすれば自動公開
+
+3. **プログラマブルな公開フロー**
+   - `published: true/false` で公開制御
+   - 下書き → 公開を Git commit で管理
+   - CI/CD との統合も可能
+
+**つまり：記事公開のすべてのステップを自動化できる**
+
+他のプラットフォーム（note、Qiita など）は Web UI が必須で自動化が難しいのに対し、Zenn は **完全に Git で管理できるため AI による自動化に最適**です。
 
 # 実現できること
 
-Discord で AI アシスタントに話しかけるだけで：
+AI アシスタントに話しかけるだけで：
 
 ```
-@AI執事 今日の学び：OpenClaw の Skill 機能便利すぎる！
+今日の学び：OpenClaw の Skill 機能便利すぎる！
 ```
 
 ↓ 5分後
@@ -36,16 +61,47 @@ Discord で AI アシスタントに話しかけるだけで：
 
 これが自動で完了します。
 
+**トリガー方法（例）:**
+- **Discord** から話しかける（本記事の例）
+- **Slack** コマンドで実行
+- **Telegram** bot に話しかける
+- **CLI** から実行
+- **Heartbeat** で定期的に実行
+
 # 前提知識
 
 ## 必要な環境
 
 - **OpenClaw がインストールされていること**
-- **GitHub アカウントと Zenn の連携**（Zenn と GitHub リポジトリ連携済み）
-- **Discord チャンネルと OpenClaw の接続**
-- **X (Twitter) アカウント** + Chrome で OpenClaw Browser Relay 拡張機能
+- **GitHub アカウント**
+- **Zenn アカウント**（GitHub 連携済み）
+- **X (Twitter) アカウント**
+- **Chrome** + OpenClaw Browser Relay 拡張機能
 
-OpenClaw の基本的なセットアップは完了している前提で進めます。
+## Zenn と GitHub の連携
+
+Zenn で記事を管理するには、GitHub リポジトリとの連携が必要です：
+
+1. Zenn にログイン: https://zenn.dev
+2. 「GitHub からのデプロイ」を選択
+3. GitHub リポジトリを作成・連携
+4. リポジトリに `articles/` フォルダを作成
+
+詳細: https://zenn.dev/zenn/articles/connect-to-github
+
+これで GitHub の master ブランチにマージすれば、自動的に Zenn に公開されます。
+
+## OpenClaw の基本セットアップ
+
+OpenClaw の基本的なインストールとセットアップは完了している前提で進めます。
+
+**インターフェース（例）:**
+- Discord チャンネル（本記事の例）
+- Slack ワークスペース
+- Telegram bot
+- CLI から直接実行
+
+どのインターフェースでも同じ Skill を使えます。
 
 # Skill の構成
 
@@ -252,17 +308,33 @@ Automate posting tweets to X (Twitter) using browser automation.
 
 # 使い方
 
-## 基本的な使い方
+## 基本的な使い方（Discord の例）
 
-Discord で AI アシスタントに話しかけるだけ：
+AI アシスタントに話しかけるだけ：
 
+**Discord の場合:**
 ```
 @AI執事 今日の学び：Tailscale と SSH でリモートアクセスが超簡単になった！
 ```
 
+**Slack の場合:**
+```
+/openclaw Zenn記事にして: Tailscale と SSH でリモートアクセスが超簡単になった
+```
+
+**Telegram の場合:**
+```
+今日の学びを Zenn 記事にまとめて
+```
+
+**CLI から実行:**
+```bash
+openclaw run "今日の学びを Zenn 記事にして"
+```
+
 すると：
 
-1. **記事執筆**: イワケンさんの体験をもとに記事が執筆される
+1. **記事執筆**: 体験をもとに記事が執筆される
 2. **PR 作成**: GitHub に feature ブランチと PR が作成される
 3. **下書き確認**: Zenn Dashboard で下書きをプレビュー
 4. **公開**: `published: true` に変更して公開
@@ -276,7 +348,7 @@ Discord で AI アシスタントに話しかけるだけ：
 **ステップ 1: 記事執筆のみ**
 
 ```
-@AI執事 OpenClaw の Skill 機能について Zenn 記事を書いて（下書きのみ）
+OpenClaw の Skill 機能について Zenn 記事を書いて（下書きのみ）
 ```
 
 **ステップ 2: 下書き確認**
@@ -286,13 +358,13 @@ Zenn Dashboard で内容を確認し、必要に応じて編集
 **ステップ 3: 公開**
 
 ```
-@AI執事 記事を公開して
+記事を公開して
 ```
 
 **ステップ 4: X 投稿**
 
 ```
-@AI執事 この記事を X で拡散して
+この記事を X で拡散して
 ```
 
 # トラブルシューティング
@@ -326,13 +398,22 @@ Zenn Dashboard で内容を確認し、必要に応じて編集
 
 # 応用例
 
-## note への展開
+## 他のプラットフォームへの展開
 
-同様の Skill を作成すれば、note への自動投稿も可能：
+同様の Skill を作成すれば、他のプラットフォームへの自動投稿も可能：
 
+**note:**
 - `note-article-writer`: note API で記事公開
 - `note-to-x`: note 記事から X ツイート生成
 - `x-post`: 既存の Skill を再利用
+
+**Qiita:**
+- Qiita API で記事投稿
+- 同様のワークフローを構築
+
+**個人ブログ:**
+- Hugo, Jekyll, Next.js などの静的サイト
+- Git push → Vercel/Netlify デプロイ → X 投稿
 
 ## 定期的な振り返り記事
 
@@ -343,30 +424,50 @@ cron と組み合わせて、週次で振り返り記事を自動生成：
 cron:
   - name: weekly-reflection
     schedule: "0 9 * * 1"  # 毎週月曜 9:00
-    command: "@AI執事 今週の学びを Zenn 記事にまとめて"
+    command: "今週の学びを Zenn 記事にまとめて"
 ```
 
-## Slack/Telegram からのトリガー
+## さまざまなトリガー方法
 
-Discord 以外のメッセージングプラットフォームからも同様に実行可能：
+OpenClaw の柔軟性を活かして、さまざまな方法で記事作成をトリガーできます：
 
-- Slack の特定チャンネルで `/zenn 記事化して` コマンド
-- Telegram の bot に話しかけて記事公開
+**メッセージングプラットフォーム:**
+- Discord: `@AI執事 Zenn 記事にして`
+- Slack: `/openclaw zenn`
+- Telegram: bot に話しかける
+- iMessage: SMS から実行
+
+**自動化:**
+- Heartbeat: 定期的にチェック
+- Git hook: commit メッセージから記事生成
+- Webhook: 外部イベントをトリガー
+
+**CLI:**
+- ローカルで直接実行
+- スクリプトから呼び出し
 
 # まとめ
 
-OpenClaw の Skill 機能を使えば、**「Discord でポチるだけ」で Zenn 記事公開 → X 拡散までを完全自動化**できます。
+OpenClaw の Skill 機能を使えば、**Zenn 記事公開 → X 拡散までを完全自動化**できます。
 
-**メリット:**
+**なぜ Zenn が自動化に最適か:**
+- ✅ GitHub で記事を管理できる
+- ✅ Git ベースのワークフロー
+- ✅ プログラマブルな公開制御
+- ✅ → AI による完全自動化が可能！
+
+**得られるメリット:**
 - ✅ 記事執筆のハードルが下がる（思いついたらすぐ記事化）
 - ✅ 公開・拡散の手間が激減（コピペ作業ゼロ）
 - ✅ ナレッジ発信の習慣化（継続しやすい）
 - ✅ 再利用可能（Skill は何度でも使える）
+- ✅ インターフェース非依存（Discord, Slack, CLI など自由に選べる）
 
 **今後の展開:**
 - X API 統合で完全自動投稿（確認なし）
 - 画像生成 AI と連携してアイキャッチ画像も自動生成
 - note、Qiita、個人ブログへの同時投稿
+- 音声入力からの記事生成
 
 OpenClaw を使えば、技術的障壁を下げてナレッジ発信を加速できます。ぜひ試してみてください！
 


### PR DESCRIPTION
修正内容：
- タイトル変更：「OpenClaw で Zenn 記事公開 → X 拡散を完全自動化する」
- Zenn の説明を追加（GitHub で管理できる → 自動化に最適）
- Discord はあくまで例として扱う（Slack, Telegram, CLI なども可能）
- トリガー方法を複数提示